### PR TITLE
If config duplicate produce an error at atom's opening

### DIFF
--- a/snippets/language-pug.cson
+++ b/snippets/language-pug.cson
@@ -80,11 +80,6 @@
 
     'if condition':
         'prefix': 'if'
-        'body': 'if ${1:condition}\n  ${2://- code}'
-
-
-    'if condition':
-        'prefix': 'if'
         'body': 'if ${1:condition}\n  ${2://- code}\nelse\n  ${3://- code}'
 
 


### PR DESCRIPTION
if config is write two times, one incomplete, i delete this and keep the other.

this cange prevent the error in Atom